### PR TITLE
Add 'second' parameter to cron::job

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -20,6 +20,7 @@ define cron::job (
   $user,
   $sync = false,
   $minute = fqdn_rand(60, $title),
+  $second='0',
   $hour='*',
   $dom='*',
   $month='*',
@@ -30,6 +31,7 @@ define cron::job (
 ) {
   # Deliberate copy here so we can add extra fancy options (like pipe stdout
   # to scribe) in additional parameters later
+  validate_cron_numeric($second)
   validate_cron_numeric($minute)
   validate_cron_numeric($hour)
   validate_cron_numeric($dom)

--- a/templates/job_cron.erb
+++ b/templates/job_cron.erb
@@ -1,4 +1,6 @@
 <%# initctl should never output anything, but if it did there would be a
 torrent of mail. Let's not let that happen. -%>
 MAILTO=""
-<%= @minute %> <%= @hour %> <%= @dom %> <%= @month %> <%= @dow %> root /sbin/initctl emit --no-wait cron_<%= @title %>
+<% scope.function_expand_cron_seconds([@second]).each do |sec| -%>
+<%= @minute %> <%= @hour %> <%= @dom %> <%= @month %> <%= @dow %> root (<% if sec != 0 -%>sleep <%= sec %>; <% end %>/sbin/initctl emit --no-wait cron_<%= @title %>)
+<% end -%>


### PR DESCRIPTION
This brings cron::job to parity with cron::d.