### PR TITLE
Enable an option to purge all of '/etc/cron.d'

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,12 +2,20 @@ require 'spec_helper'
 
 describe 'cron' do
 
+  let(:facts) {{
+    :operatingsystemrelease => '14.04'
+  }}
+
   context 'by default' do
-   let(:facts) {{
-     :operatingsystemrelease => '14.04'
-   }}
-   it { should compile }
-   it { should contain_file('/nail/sys/bin/cron_staleness_check') }
+    it { should compile }
+    it { should_not contain_file('/etc/cron.d') }
+    it { should contain_file('/nail/sys/bin/cron_staleness_check') }
+  end
+
+  context 'when asked to purge cron.d' do
+    let(:params) {{ :purge_cron_d => true }}
+    it { should compile }
+    it { should contain_file('/etc/cron.d').with_purge(true) }
   end
 
 end


### PR DESCRIPTION
Primary: @hashbrowncipher 

I think we have finally arrived. We are at the point where I think we, at yelp, can purge all the cron jobs.

Here is my audit on a subset of our servers:

```
    955  /etc/cron.d/sysstat
    955  /etc/cron.d/.placeholder
    939  /etc/cron.d/mdadm
    131  /etc/cron.d/php5
     30  /etc/cron.d/mcelog.dpkg-bak
     12  /etc/cron.d/mcelog
     12  /etc/cron.d/atop
      5  /etc/cron.d/cacti
      4  /etc/cron.d/apt-mirror.dpkg-dist
      2  /etc/cron.d/restart-nagios
      2  /etc/cron.d/restart-nagdash-collector
      2  /etc/cron.d/request-tracker4
      2  /etc/cron.d/mysql_status
      2  /etc/cron.d/MegaSAS.log
      1  /etc/cron.d/top_30_trac_pages
      1  /etc/cron.d/syslog-ng
      1  /etc/cron.d/sensu_server_chaos_monkey
      1  /etc/cron.d/sensu_dashboard_chaos_monkey
      1  /etc/cron.d/sensu_api_chaos_monkey
      1  /etc/cron.d/s3ked
      1  /etc/cron.d/redis_sentinel_chaos_monkey
      1  /etc/cron.d/redis_chaos_monkey
      1  /etc/cron.d/rabbitmq_chaos_monkey
      1  /etc/cron.d/puppetmaster-cleanup-templates
      1  /etc/cron.d/puppetmaster-clean-certs
      1  /etc/cron.d/nameomatic
      1  /etc/cron.d/mysql-zrm-new-testrtbackup
      1  /etc/cron.d/mrjob_monitoring
      1  /etc/cron.d/mrjob_collect_emr_stats
      1  /etc/cron.d/iam_admin
      1  /etc/cron.d/git-mirror
      1  /etc/cron.d/generate_ssh_known_hosts
      1  /etc/cron.d/email_old_acks
      1  /etc/cron.d/dmits_iproute2_git_commit
      1  /etc/cron.d/cloudinit-updates
      1  /etc/cron.d/bchess-test
      1  /etc/cron.d/amdump
      1  /etc/cron.d/alert_counts
```

Let's purge this crap!
