### PR TITLE
Parameterize the nagios script location for cron_staleness_check

### DIFF
--- a/manifests/d.pp
+++ b/manifests/d.pp
@@ -81,8 +81,6 @@ define cron::d (
 
   validate_bool($log_to_syslog,$lock)
 
-  include cron
-
   $safe_name = regsubst($name, ':', '_', 'G')
   $reporting_name = "cron_${safe_name}"
 

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -8,6 +8,10 @@
 define cron::file (
   $file_params,
 ) {
+  # We require that cron be declared somewhere.
+  # This realize verifies that for us.
+  realize Class['cron']
+
   validate_re($title, '^[^/.]+$')
 
   validate_hash($file_params)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,14 @@
 # Main class to get the cron infrastructure in place for the other
 # types. Enablings the cron job purging mechanism.
 #
+# === Parameters
+#
+# [*check_file_age_path*]
+#
+# path to a nagios-compatible check_file_age script
+#
 class cron (
+  $check_file_age_path = '/usr/lib/nagios/plugins/check_file_age',
   $conf_dir = '/nail/etc',
   $scripts_dir = '/nail/sys/bin',
   $purge_upstart_jobs = true,
@@ -57,10 +64,10 @@ class cron (
   }
 
   file { "${scripts_dir}/cron_staleness_check":
-    mode   => '0555',
-    owner  => 'root',
-    group  => 'root',
-    source => 'puppet:///modules/cron/cron_staleness_check',
+    mode    => '0555',
+    owner   => 'root',
+    group   => 'root',
+    content => template('cron/cron_staleness_check.erb'),
   }
 
   file { "${scripts_dir}/initial_cron_run":

--- a/spec/defines/d_spec.rb
+++ b/spec/defines/d_spec.rb
@@ -5,6 +5,7 @@ describe 'cron::d' do
   let(:facts) {{
     :operatingsystemrelease => '14.04'
   }}
+  let(:pre_condition) { "class { 'cron': }" }
   let(:params) {{
     :minute  => 37,
     :user    => 'somebody',

--- a/spec/defines/file_spec.rb
+++ b/spec/defines/file_spec.rb
@@ -4,6 +4,9 @@ describe 'cron::file' do
   let(:params) {{
     :file_params => {}
   }}
+  let(:facts) {{
+    :operatingsystemrelease => '14.04'
+  }}
   let(:pre_condition) { "class { 'cron': }" }
 
   context 'with correct title' do

--- a/spec/defines/file_spec.rb
+++ b/spec/defines/file_spec.rb
@@ -4,6 +4,7 @@ describe 'cron::file' do
   let(:params) {{
     :file_params => {}
   }}
+  let(:pre_condition) { "class { 'cron': }" }
 
   context 'with correct title' do
     let(:title) { 'foobar' }

--- a/templates/cron_staleness_check.erb
+++ b/templates/cron_staleness_check.erb
@@ -16,7 +16,7 @@ function get_context {
 name=$1
 threshold_s=$2
 
-/usr/lib/nagios/plugins/check_file_age "/nail/run/success_wrapper/${name}" -w ${threshold_s} -c ${threshold_s} >/dev/null
+<%= @check_file_age_path %> "/nail/run/success_wrapper/${name}" -w ${threshold_s} -c ${threshold_s} >/dev/null
 return_code=$?
 
 last_success=$(stat -c %z "/nail/run/success_wrapper/${name}")


### PR DESCRIPTION
Since we don't manage the installation of this file, we should be compatible with wherever the OS has chosen to put it.