### PR TITLE
Require a value for the mailto parameter beyond an empty string.

### DIFF
--- a/manifests/d.pp
+++ b/manifests/d.pp
@@ -85,6 +85,10 @@ define cron::d (
 
   validate_bool($log_to_syslog,$lock)
 
+  if $mailto == '' {
+    fail('You must provide a value for MAILTO. Did you mean mailto=\'""\'?')
+  }
+
   $safe_name = regsubst($name, ':', '_', 'G')
   $reporting_name = "cron_${safe_name}"
 


### PR DESCRIPTION
A value of mailto='' will result in the line MAILTO= being written out. This is illegal and will cause the job to fail to run, oftentimes silently. We should catch these and reject them.