### PR TITLE
/nail/sys/bin/yelp_timeout referenced by timeout parameter

### DIFF
--- a/manifests/d.pp
+++ b/manifests/d.pp
@@ -107,6 +107,13 @@ define cron::d (
   # If both syslogging and mailing are requested, choose mailing over syslogging
   $actually_log_to_syslog = $log_to_syslog and $mailto=='""'
 
+  # Ancient versions of `timeout` have a slightly different argument syntax
+  # for what signal should be sent.
+  $timeout_signal_arg = "${::lsbdistid}_${::lsbdistrelease}" ? {
+    /(Ubuntu_10.04|CentOS_5.*)/ => '-9',
+    default => '-s 9'
+  }
+
   cron::file { $safe_name:
     file_params => {
       content => template('cron/d.erb'),

--- a/spec/defines/d_spec.rb
+++ b/spec/defines/d_spec.rb
@@ -163,9 +163,9 @@ describe 'cron::d' do
     it {
       should contain_file('/nail/etc/cron.d/foobar') \
         .with_content(%r{
-          \*\ \*\ \*\ \*\ \*\ nobody\ \(flock\ -n\ "/var/lock/cron_foobar.lock"\ \/nail\/sys\/bin\/yelp_timeout\ -s\ 9\ 2h\ echo\ hi\).*\n
-          \*\ \*\ \*\ \*\ \*\ nobody\ \(sleep\ 20;\ flock\ -n\ "/var/lock/cron_foobar.lock"\ \/nail\/sys\/bin\/yelp_timeout\ -s\ 9\ 2h\  echo\ hi\).*\n
-          \*\ \*\ \*\ \*\ \*\ nobody\ \(sleep\ 40;\ flock\ -n\ "/var/lock/cron_foobar.lock"\ \/nail\/sys\/bin\/yelp_timeout\ -s\ 9\ 2h\ echo\ hi\).*\n
+          \*\ \*\ \*\ \*\ \*\ nobody\ \(flock\ -n\ "/var/lock/cron_foobar.lock"\ \/usr\/bin\/timeout\ -s\ 9\ 2h\ echo\ hi\).*\n
+          \*\ \*\ \*\ \*\ \*\ nobody\ \(sleep\ 20;\ flock\ -n\ "/var/lock/cron_foobar.lock"\ \/usr\/bin\/timeout\ -s\ 9\ 2h\  echo\ hi\).*\n
+          \*\ \*\ \*\ \*\ \*\ nobody\ \(sleep\ 40;\ flock\ -n\ "/var/lock/cron_foobar.lock"\ \/usr\/bin\/timeout\ -s\ 9\ 2h\ echo\ hi\).*\n
         }x)
     }
   end

--- a/templates/d.erb
+++ b/templates/d.erb
@@ -13,5 +13,5 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin:/usr/local/sbin
 <%= k %>="<%= v %>"
 <% end -%>
 <% scope.function_expand_cron_seconds([@second]).each do |sec| -%>
-<%= @minute %> <%= @hour %> <%= @dom %> <%= @month %> <%= @dow %> <%= @user %> (<% if sec != 0 -%>sleep <%= sec %>; <% end %><% if @lock -%>flock -n "/var/lock/<%= @reporting_name -%>.lock" <% end %><% if @timeout -%>/nail/sys/bin/yelp_timeout -s 9 <%= @timeout -%> <% end %><%= @actual_command %>)<% if @actually_log_to_syslog -%> 2>&1 | logger -t <%= @reporting_name %> <% end %>
+<%= @minute %> <%= @hour %> <%= @dom %> <%= @month %> <%= @dow %> <%= @user %> (<% if sec != 0 -%>sleep <%= sec %>; <% end %><% if @lock -%>flock -n "/var/lock/<%= @reporting_name -%>.lock" <% end %><% if @timeout -%>/usr/bin/timeout <%= @timeout_signal_arg -%> <%= @timeout -%> <% end %><%= @actual_command %>)<% if @actually_log_to_syslog -%> 2>&1 | logger -t <%= @reporting_name %> <% end %>
 <% end -%>


### PR DESCRIPTION
Just a heads up that the yelp_timeout script (allows us to be agnostic to various versions of timeout that our systems have) is a Yelpism we should probably get rid of.

Let's just open source yelp_timeout in this package maybe? Or we can make the timeout command configurable (so we would do yelp_timeout -s ...)