### PR TITLE
check whether sensu is included in staleness_threshold

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
     ipaddress (0.8.3)
     json (1.8.3)
     json_pure (1.8.3)
-    jwt (1.5.3)
+    jwt (1.5.4)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.0.6)

--- a/manifests/d.pp
+++ b/manifests/d.pp
@@ -98,7 +98,7 @@ define cron::d (
   $safe_name = regsubst($name, ':', '_', 'G')
   $reporting_name = "cron_${safe_name}"
 
-  if $staleness_threshold {
+  if $staleness_threshold and defined(Class['sensu']) {
     $actual_command = "/nail/sys/bin/success_wrapper '${reporting_name}' ${command}"
 
     cron::staleness_check { $reporting_name:

--- a/spec/defines/d_spec.rb
+++ b/spec/defines/d_spec.rb
@@ -7,7 +7,7 @@ describe 'cron::d' do
     :lsbdistid => 'Ubuntu',
     :lsbdistrelease => '14.04',
   }}
-  let(:pre_condition) { [(site_pp rescue ""), "class { 'cron': }"] }
+  let(:pre_condition) { [(site_pp rescue ""), "class { ['sensu','cron']: }"] }
   let(:params) {{
     :minute  => 37,
     :user    => 'somebody',
@@ -45,6 +45,22 @@ describe 'cron::d' do
       should contain_file('/nail/etc/cron.d/foobar') \
         .with_content(/success_wrapper 'cron_foobar'/)
       should contain_cron__staleness_check('cron_foobar')
+    }
+  end
+
+  context 'with staleness when Class["sensu"] is not defined' do
+    let(:params) {{
+      :minute    => 37,
+      :user      => 'somebody',
+      :command   => 'foobar | logger -t cleanup-srv-deploy -p daemon.info',
+      :staleness_threshold => '10m',
+      :staleness_check_params => { 'runbook' => 'y/rb-foobar' },
+    }}
+    let(:pre_condition) { [(site_pp rescue ""), "class { 'cron': }"] }
+    it {
+      should have_cron__staleness_check_resource_count(0)
+      should contain_file('/nail/etc/cron.d/foobar') \
+        .with_content(/(?!success_wrapper)/)
     }
   end
 

--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -26,3 +26,4 @@ define monitoring_check (
     $aggregate             = false,
     $sensu_custom          = {},
 ) {}
+class sensu {}


### PR DESCRIPTION
If staleness_threshold is set but sensu is not included, catalog compile will fail due to https://github.com/Yelp/puppet-monitoring_check/blob/master/manifests/init.pp#L289

This PR fixes this problem.

jwt 1.5.3 no longer exists on rubygems.org, bumped to current version.