### PR TITLE
Fix broken example by adding required minute field

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ has.
 Example: An important cron job that makes tickets after failing for 24h hours:
 ```puppet
 cron::d { 'name_of_cronjob':
+  minute                 => '0',
   hour                   => '4',
   user                   => 'root',
   command                => 'fortune';


### PR DESCRIPTION
The example can be slightly misleading because you still need to provide the `minute` parameter, because otherwise it will throw errors.