### PR TITLE
Allow us to toggle whether cron should be ensured to be running or not

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,12 +9,17 @@
 #
 # path to a nagios-compatible check_file_age script
 #
+# [*service_ensure*]
+#
+# How Puppet should manage the service. Defaults to 'running'.
+#
 class cron (
   $check_file_age_path = '/usr/lib/nagios/plugins/check_file_age',
   $conf_dir = '/nail/etc',
   $scripts_dir = '/nail/sys/bin',
   $purge_upstart_jobs = true,
   $package_ensure = 'latest',
+  $service_ensure = 'running',
 ) {
 
   include nail
@@ -86,7 +91,7 @@ class cron (
   } ->
   service { 'cron':
     name   => $service_name,
-    ensure => 'running',
+    ensure => $service_ensure,
     enable => true,
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,4 +13,18 @@ describe 'cron' do
    it { should contain_file('/nail/sys/bin/cron_staleness_check') }
   end
 
+  context 'with service ensure stopped' do
+    let(:facts) {{
+      :lsbdistid => 'Ubuntu',
+      :lsbdistrelease => '16.04',
+      :operatingsystemrelease => '16.04',
+      :osfamily => 'Debian',
+    }}
+    let(:params) {{
+      :service_ensure => 'stopped'
+    }}
+    it { should compile }
+    it { should contain_service('cron').with_ensure('stopped') }
+  end
+
 end


### PR DESCRIPTION
When we're baking AMIs, we don't want cron to run. At the moment it'll be forcibly started by Puppet; this change lets us potentially override that, so we could have an `if $::ami_baking` wrapped around the invocation to the cron module proper.